### PR TITLE
Fixed XML (was not well-formed)

### DIFF
--- a/org/exist-db/existdb-index-lucene/2.1/existdb-index-lucene-2.1.pom
+++ b/org/exist-db/existdb-index-lucene/2.1/existdb-index-lucene-2.1.pom
@@ -14,8 +14,8 @@
     </organization>
 
     <properties>
-        <lucene.version>3.6.1</lucene.version>>
-    <properties>
+        <lucene.version>3.6.1</lucene.version>
+    </properties>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
The pom was not well-formed so Maven ignored the transient dependencies. This works now.
